### PR TITLE
Oxide: Make sure to exclude GitInfo from deps.

### DIFF
--- a/src/Oxide/Oxide.csproj
+++ b/src/Oxide/Oxide.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="1.1.63" />
+    <PackageReference Include="GitInfo" Version="1.1.63" PrivateAssets="All" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />


### PR DESCRIPTION
This should be automatic, but is not. See
https://github.com/NuGet/Home/issues/4125.