### PR TITLE
Oxide: Add support for deconstructing Result<T, E>.

### DIFF
--- a/src/Oxide.Tests/Oxide.Tests.csproj
+++ b/src/Oxide.Tests/Oxide.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Oxide.Tests/ResultTests.cs
+++ b/src/Oxide.Tests/ResultTests.cs
@@ -80,6 +80,18 @@ namespace Oxide.Tests
         }
 #endregion
 
+#region Deconstruction
+        [Fact]
+        public void Can_deconstruct_result_into_value_and_error()
+        {
+            var res = Ok<int, Exception>(5);
+            (var number, var exception) = res;
+
+            Assert.Equal(5, number);
+            Assert.Null(exception);
+        }
+#endregion
+
 #region Equality Tests
         [Fact]
         public void Result_equals_null_is_false()

--- a/src/Oxide/Result.cs
+++ b/src/Oxide/Result.cs
@@ -114,6 +114,12 @@ namespace Oxide
             return ReferenceEquals(error, null) ? -2 : error.GetHashCode();
         }
 
+        public void Deconstruct(out T value, out E error)
+        {
+            value = this.value;
+            error = this.error;
+        }
+
         public static bool operator==(Result<T, E> left, Result<T, E> right)
             => Equals(left, right);
 


### PR DESCRIPTION
C# 7 added support for structurally typed deconstruction--that is, anything
with a Deconstruct method and a list of out parameters can be deconstructed
as if it was a tuple: (var a, var b) = somethingDeconstructible.

Add support for deconstructing Result<T, E> into a T and E variable, without
throwing any exceptions for Err<T, E>.