### PR TITLE
Result: Add TryUnwrap and TryUnwrapError.

### DIFF
--- a/src/Oxide.Tests/ResultTests.cs
+++ b/src/Oxide.Tests/ResultTests.cs
@@ -420,6 +420,34 @@ namespace Oxide.Tests
         [Fact]
         public void Unwrap_or_default_on_err_returns_default_value()
             => Assert.Equal(default(string), Err<string, int>(5).UnwrapOrDefault());
+
+        [Fact]
+        public void Can_try_unwrap_for_pattern_matching()
+        {
+            var ok = Ok<int, string>(10);
+            switch (ok) {
+                case var _ when ok.TryUnwrap(out var result):
+                    Assert.Equal(10, result);
+                    break;
+                case var _ when ok.TryUnwrapError(out var error):
+                    Assert.True(false, "Should not be reached.");
+                    break;
+            }
+        }
+
+        [Fact]
+        public void Can_try_unwrap_error_for_pattern_matching()
+        {
+            var ok = Err<int, string>("error");
+            switch (ok) {
+                case var _ when ok.TryUnwrap(out var result):
+                    Assert.True(false, "Should not be reached.");
+                    break;
+                case var _ when ok.TryUnwrapError(out var error):
+                    Assert.Equal("error", error);
+                    break;
+            }
+        }
         #endregion
 
         #region Combined result tests

--- a/src/Oxide/Result.cs
+++ b/src/Oxide/Result.cs
@@ -172,6 +172,11 @@ namespace Oxide
             return default(T);
         }
 
+        public bool TryUnwrap(out T value) {
+            value = this.value;
+            return IsOk;
+        }
+
         public T Expect(string msg) {
             if (IsOk)
                 return value;
@@ -185,6 +190,11 @@ namespace Oxide
             if (IsError)
                 return error;
             throw new Exception(value.ToString());
+        }
+
+        public bool TryUnwrapError(out E error) {
+            error = this.error;
+            return IsError;
         }
 
         public E ExpectError(string msg) {


### PR DESCRIPTION
Both of these APIs contribute to much better usability of Result<T, E>
with C# pattern matching. These APIs enable you to write code like this:

```
var result = await GetWidgetAsync(...).AndThen(...);
switch (result) {
    case var _ when result.TryUnwrap(out var widget):
        UseWidget(widget);
	break;
    case var _ when result.TryUnwrapError(out var error):
        HandleWidgetError(error);
	break;
}
```

This is a huge improvement over jumbled if/else and painful manual
unwrapping. Thanks to @lewing for the API suggestions.