### PR TITLE
Oxide: Add some helpers for head/tail or first/rest of enumerables.

### DIFF
--- a/src/Oxide.Tests/EnumerableTests.cs
+++ b/src/Oxide.Tests/EnumerableTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+using Oxide;
+
+namespace Oxide.Tests
+{
+    public class EnumerableTests
+    {
+        static readonly string[] sequence = {
+            "rose", "violet", "daisy", "buttercup" 
+        };
+
+        [Fact]
+        public void Calling_tail_returns_remainder_of_sequence() =>
+            Assert.Equal(new [] {
+                "violet",
+                "daisy",
+                "buttercup"
+            }, sequence.Tail());
+
+        [Fact]
+        public void Calling_head_is_equivalent_to_first() =>
+            Assert.Equal("rose", sequence.Head());
+
+        [Fact]
+        public void Calling_rest_is_equivalent_to_tail() =>
+            Assert.Equal(sequence.Tail(), sequence.Rest());
+    }
+}

--- a/src/Oxide/EnumerableExtensions.cs
+++ b/src/Oxide/EnumerableExtensions.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Oxide
+{
+    public static class EnumerableExtension
+    {
+        public static T Head<T>(this IEnumerable<T> self) =>
+            self.First();
+
+        public static IEnumerable<T> Tail<T>(this IEnumerable<T> self) =>
+            self.Skip(1);
+
+        public static IEnumerable<T> Rest<T>(this IEnumerable<T> self) =>
+            self.Tail();
+    }
+}


### PR DESCRIPTION
Fixes #9.