### PR TITLE
Add another unwrap overload, add tests for positional patterns

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,11 @@ steps:
       gitversion /output buildserver /updateAssemblyInfo
       dotnet tool install -g sleet
     displayName: 'Install dependencies and generate version number'
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      packageType: sdk
+      version: 3.0.100-preview6-012264
   - task: DotNetCoreCLI@2
     inputs:
       command: 'restore'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ strategy:
       buildConfiguration: 'Release'
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2019'
   
 steps:
   - script: |

--- a/src/Oxide.Tests/ResultTests.cs
+++ b/src/Oxide.Tests/ResultTests.cs
@@ -436,6 +436,30 @@ namespace Oxide.Tests
         }
 
         [Fact]
+        public void Can_try_unwrap_both_and_output_value()
+        {
+            var ok = Ok<int, string>(10);
+            if (ok.TryUnwrap(out var value, out var error)) {
+                Assert.Equal(10, value);
+                Assert.Null(error);
+            } else {
+                Assert.False(true, "Should not be reached, TryUnwrap returned false for Ok<T, E>.");
+            }
+        }
+
+        [Fact]
+        public void Can_try_unwrap_both_and_output_error()
+        {
+            var error = Err<int, string>("error");
+            if (error.TryUnwrap(out var value, out var err)) {
+                Assert.False(true, "Should not be reached, TryUnwrap returned true for Error<T, E>.");
+            } else {
+                Assert.Equal(default(int), value);
+                Assert.Equal("error", err);
+            }
+        }
+
+        [Fact]
         public void Can_try_unwrap_error_for_pattern_matching()
         {
             var ok = Err<int, string>("error");

--- a/src/Oxide.Tests/ResultTests.cs
+++ b/src/Oxide.Tests/ResultTests.cs
@@ -460,6 +460,28 @@ namespace Oxide.Tests
         }
 
         [Fact]
+        public void Can_use_positional_patterns_with_ok()
+        {
+            var ok = Ok<int, string>(10);
+            var val = ok switch {
+                var (value, error) when ok.IsOk => value*10,
+                var (value, error) when ok.IsError => -1
+            };
+            Assert.Equal(10*10, val);
+        }
+
+        [Fact]
+        public void Can_use_positional_patterns_with_err()
+        {
+            var err = Err<int, string>("hello");
+            var val = err switch {
+                var (value, error) when err.IsOk => null,
+                var (value, error) when err.IsError => error.ToUpper()
+            };
+            Assert.Equal("HELLO", val);
+        }
+
+        [Fact]
         public void Can_try_unwrap_error_for_pattern_matching()
         {
             var ok = Err<int, string>("error");

--- a/src/Oxide/Result.cs
+++ b/src/Oxide/Result.cs
@@ -176,6 +176,12 @@ namespace Oxide
             return IsOk;
         }
 
+        public bool TryUnwrap(out T value, out E error) {
+            value = this.value;
+            error = this.error;
+            return IsOk;
+        }
+
         public T Expect(string msg) {
             if (IsOk)
                 return value;

--- a/src/Oxide/Result.cs
+++ b/src/Oxide/Result.cs
@@ -177,8 +177,7 @@ namespace Oxide
         }
 
         public bool TryUnwrap(out T value, out E error) {
-            value = this.value;
-            error = this.error;
+            Deconstruct(out value, out error);
             return IsOk;
         }
 


### PR DESCRIPTION
Adds a `TryUnwrap(T, E)` overload, and add some tests for combining deconstruction and positional patterns.

Also updates to a newer image + .NET Core in CI, because it's needed for positional patterns.