### PR TITLE
Better async result handling

### DIFF
--- a/src/Oxide.Tests/ResultTests.cs
+++ b/src/Oxide.Tests/ResultTests.cs
@@ -229,6 +229,16 @@ namespace Oxide.Tests
             => Assert.Equal (4, Err<int, string>("taco").MapErr(s => s.Length).Err());
 
         [Fact]
+        public async Task Continue_task_of_result_without_await()
+        {
+            var task = Task.FromResult(Ok<int, string>(10));
+            var result = await task.AndThen(i => Ok<int, string>(i*5));
+
+            Assert.True(result.IsOk);
+            Assert.Equal(50, result.Unwrap());
+        }
+
+        [Fact]
         public async Task Async_map_err_on_ok_returns_ok()
             => Assert.Equal (10, await Ok<int, string>(10).MapErr<TimeSpan>(async s => {
                 var ts = TimeSpan.FromMilliseconds(s.Length * 100);

--- a/src/Oxide/Result.cs
+++ b/src/Oxide/Result.cs
@@ -24,6 +24,13 @@ namespace Oxide
                     return e;
                 }
             };
+
+        public static async Task<Result<TOut, TError>> AndThen<TIn, TOut, TError>(
+            this Task<Result<TIn, TError>> resTask,
+            Func<TIn, Result<TOut, TError>> continuation
+        ) {
+            return (await resTask).AndThen(continuation);
+        }
     }
 
     public abstract class Result


### PR DESCRIPTION
Add an `AndThen` extension to `Task<Result<T, E>>` to make chaining async results easier.