### PR TITLE
Result: Add a second form of AndThen on Task<Result<...>>.

### DIFF
--- a/src/Oxide.Tests/ResultTests.cs
+++ b/src/Oxide.Tests/ResultTests.cs
@@ -239,6 +239,16 @@ namespace Oxide.Tests
         }
 
         [Fact]
+        public async Task Continue_task_of_result_with_async_continuation()
+        {
+            var task = Task.FromResult(Ok<int, string>(10));
+            var result = await task.AndThen(async i => await Task.FromResult(Ok<int, string>(i*5)));
+
+            Assert.True(result.IsOk);
+            Assert.Equal(50, result.Unwrap());
+        }
+
+        [Fact]
         public async Task Async_map_err_on_ok_returns_ok()
             => Assert.Equal (10, await Ok<int, string>(10).MapErr<TimeSpan>(async s => {
                 var ts = TimeSpan.FromMilliseconds(s.Length * 100);

--- a/src/Oxide/Result.cs
+++ b/src/Oxide/Result.cs
@@ -31,6 +31,14 @@ namespace Oxide
         ) {
             return (await resTask).AndThen(continuation);
         }
+
+        public static async Task<Result<TOut, TError>> AndThen<TIn, TOut, TError>(
+            this Task<Result<TIn, TError>> self,
+            Func<TIn, Task<Result<TOut, TError>>> continuation
+        ) {
+            var ret = await self;
+            return await ret.AndThen(continuation);
+        }
     }
 
     public abstract class Result


### PR DESCRIPTION
This is actually the more useful form, because it can take async continuations.