### PR TITLE
CI: Fix license expression, NuGet upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,8 @@ jobs:
       with:
         dotnet-version: 3.1.201
     - name: Push To NuGet
-      run: >
-        dotnet
-        nuget
-        push
-        --api-key ${{ secrets.NUGET_API_KEY }}
-        --source https://api.nuget.org/v3/index.json
-        ./NuGet\ Packages/*.nupkg
+      run: |
+        find . -name '*.nupkg' -exec dotnet nuget push --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json {} \;
   push_to_gh:
     name: Push To GitHub Packages
     runs-on: ubuntu-latest

--- a/src/Oxide.Http/Oxide.Http.csproj
+++ b/src/Oxide.Http/Oxide.Http.csproj
@@ -8,7 +8,7 @@
     <Description>HTTP extensions using Oxide.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/bojanrajkovic/Oxide</PackageProjectUrl>
-    <PackageLicense>MIT</PackageLicense>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>rust kotlin functional http</PackageTags>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>

--- a/src/Oxide/Oxide.csproj
+++ b/src/Oxide/Oxide.csproj
@@ -8,7 +8,7 @@
     <Description>A library of Rust-like types and helpers for .NET.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/bojanrajkovic/Oxide</PackageProjectUrl>
-    <PackageLicense>MIT</PackageLicense>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>rust kotlin functional</PackageTags>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>


### PR DESCRIPTION
Use `<PackageLicenseExpression />`, as per documentation, and do NuGet push a little differently to make sure Oxide.Http gets caught.